### PR TITLE
Update marshal options

### DIFF
--- a/dyanbuf.go
+++ b/dyanbuf.go
@@ -12,6 +12,12 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+var (
+	marshalOptions = protojson.MarshalOptions{
+		EmitDefaultValues: true,
+	}
+)
+
 // Set of error messages that can be returned by the [Marshal] and [Unmarshal] functions.
 var (
 	// ErrFailedToMarshal is returned when the function fails to marshal a protobuf message to a DynamoDB attribute value.
@@ -95,7 +101,7 @@ func marshalProtoMessage(v any) (map[string]dbtypes.AttributeValue, error) {
 		return nil, fmt.Errorf("%w: %w: %T", ErrFailedToMarshal, ErrInvalidInput, v)
 	}
 
-	b, err := protojson.Marshal(v.(proto.Message))
+	b, err := marshalOptions.Marshal(v.(proto.Message))
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrFailedToMarshal, err)
 	}

--- a/dyanbuf.go
+++ b/dyanbuf.go
@@ -16,6 +16,9 @@ var (
 	marshalOptions = protojson.MarshalOptions{
 		EmitDefaultValues: true,
 	}
+	unmarshalOptions = protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}
 )
 
 // Set of error messages that can be returned by the [Marshal] and [Unmarshal] functions.
@@ -262,7 +265,7 @@ func Unmarshal(av any, v any) error {
 	if isSlice {
 		err = unmarshalJSONToProtoSlice(intermediateBytes, v)
 	} else {
-		err = protojson.Unmarshal(intermediateBytes, v.(proto.Message))
+		err = unmarshalOptions.Unmarshal(intermediateBytes, v.(proto.Message))
 	}
 	if err != nil {
 		return fmt.Errorf("%w: %w: %w", ErrFailedToUnmarshal, ErrFailedToUnmarshalIntermediary, err)
@@ -282,7 +285,7 @@ func unmarshalJSONToProtoSlice(data []byte, v any) error {
 	for _, item := range jsonSlice {
 		elemType := slice.Type().Elem()
 		elem := reflect.New(elemType.Elem()).Interface().(proto.Message)
-		if err := protojson.Unmarshal(item, elem); err != nil {
+		if err := unmarshalOptions.Unmarshal(item, elem); err != nil {
 			return err
 		}
 		slice.Set(reflect.Append(slice, reflect.ValueOf(elem)))


### PR DESCRIPTION
This PR adds custom `protojson` options when (un)marshaling data. Now, default values will be emitted, which makes filter expressions feel more natural. 

So, when you have a message:

```proto
message Task {
  bool completed = 1;
}
```

Then create one you want to insert into DynamoDB:

```go
pb.Task{
  Completed: false,
}
```

It will marshal as:

```go
map[string]types.AttributeValue{
  "completed": types.AttributeValue(types.AttributeValueMemberBOOL),
}
```

Whereas previously, it would result in an **empty** attribute value map, being an unset/default boolean field (because it is `false`).

---

This would lead to situations where the following CEL `expr` filter might not work as expected, because it wouldn't be known by DynamoDB (because the `completed` field was never inserted).

```go
completed == false
```

Now, it should work as expected.

---

> [!IMPORTANT]
> While making this change, I decided to also allow for slightly lenient unmarhalling, allowing for unknown fields retrieved from DynamoDB to be discarded (essentially ignored). I expect this to be a nicer behavior for users in most situations. This is not fully tested itself.